### PR TITLE
Fix create account- encode URI

### DIFF
--- a/src/components/Auth/Auth.jsx
+++ b/src/components/Auth/Auth.jsx
@@ -84,6 +84,11 @@ export default function Auth() {
   // Handles creation of account and calls sign in action
   const createAccount = async (userName, userPass) => {
     try {
+      // encode username and userpass - it may have # $ & + ,  / : ; = ? @ [ ]
+
+      userName = encodeURIComponent(userName);
+      userPass = encodeURIComponent(userPass);
+
       const response = await axios.post(`/user/create?userName=${userName}&userPass=${userPass}`);
       if (rememberMe) {
         localStorage.setItem('user', JSON.stringify(response.data));


### PR DESCRIPTION
Encode URI before making request to create account. 
Why this is needed ? because you are making a post request with username and userpass as query params in post URI. If some user wants `&` in his/her username/userpass (like userpass=T&1234&t) then what server will see is `userpass=T`. Thats why it was throwing error of password having less than 6 characters.